### PR TITLE
CONC Command: Fix issue with delimeter variable being re-assigned in a wrong way

### DIFF
--- a/src/senscript/Command_CONC.java
+++ b/src/senscript/Command_CONC.java
@@ -22,9 +22,9 @@ public class Command_CONC extends Command {
 	public double execute() {
 		String v1 = sensor.getScript().getVariableValue(arg2);
 		String v2 = sensor.getScript().getVariableValue(arg3);
-		symbol = sensor.getScript().getVariableValue(symbol);
-		if(symbol.equals("\\")) symbol = "";
-		String z = v1+symbol+v2;
+		String delim = sensor.getScript().getVariableValue(symbol);
+		if(delim.equals("\\")) delim = "";
+		String z = v1+delim+v2;
 		WisenSimulation.simLog.add("S" + sensor.getId() + " " + arg1 + " = (" + v1 + ") + (" + v2 + ") -> " + z);
 		sensor.getScript().addVariable(arg1, z);
 		return 0 ;


### PR DESCRIPTION
## Description

This pull request addresses a variable assignment issue encountered during **CONC** command execution. 
The problem arised from the re-assignment of the `symbol` variable, which, in certain cases, was not being reset to its initial value. This behavior occurred due to references to the same object in memory.

To rectify this issue, a new variable named `delim` has been introduced. This change ensures that `symbol` retains its original value, while `delim` is used as the delimiter for string concatenation.

## Code example

```
set result ""
loop
	conc result "" result "A"
	cprint result
```

> Exception in thread "Thread-17" java.lang.StringIndexOutOfBoundsException: String index out of range: 0
	at java.lang.String.charAt(String.java:658)
	at senscript.SenScript.getVariableValue(SenScript.java:178)
	at senscript.Command_CONC.execute(Command_CONC.java:25)
	at senscript.SenScript.executeCommand(SenScript.java:152)
	at device.SensorNode.execute(SensorNode.java:679)
	at simulation.WisenSimulation.start_simulation(WisenSimulation.java:253)
	at simulation.WisenSimulation.simulate(WisenSimulation.java:74)
	at simulation.WisenSimulation.run(WisenSimulation.java:479)
	at java.lang.Thread.run(Thread.java:748)
